### PR TITLE
Some editorial fixes

### DIFF
--- a/draft-edm-protocol-greasing.md
+++ b/draft-edm-protocol-greasing.md
@@ -145,7 +145,7 @@ find it too costly to dedicate many grease values, while 32-bit or 64-bit
 fields are likely to have no such limitations.
 
 It is recommended to use an algorithm to reserve large sets of values.
-For example, {{QUIC}} use and algorithm of `31 * N + 27` to allocate
+For example, {{QUIC}} uses an algorithm of `31 * N + 27` to allocate
 grease values for transport parameters.
 
 One possible problem with some algorithms is that they will spread out


### PR DESCRIPTION
1. Fix grammar
2. Change "client" to "sender" since greasing isn't just for "clients" and some protocols don't have a role called "client" per se but use other terms instead.